### PR TITLE
feat: Add Display trait implementation and optional support for `interactive-clap`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ description = "near-gas is crate for work with gas data in near-protocol."
 serde = { version = "1", features = ["derive"], optional = true }
 borsh = { version = "0.9", features = ["const-generics"], optional = true }
 schemars = { version = "0.8.8", optional = true }
+interactive-clap = { version = "0.2.4", optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,10 +65,9 @@ impl std::str::FromStr for NearGas {
     }
 }
 
-impl std::convert::TryFrom<String> for NearGas {
-    type Error = NearGasError;
-    fn try_from(s: String) -> Result<Self, Self::Error> {
-        NearGas::from_str(&s)
+impl std::convert::From<String> for NearGas {
+    fn from(s: String) -> NearGas {
+        NearGas::from_str(&s).unwrap_or(NearGas::from_gas(0))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,11 @@ impl NearGas {
     }
 }
 
+#[cfg(feature = "interactive-clap")]
+impl interactive_clap::ToCli for NearGas {
+    type CliVariant = NearGas;
+}
+
 #[cfg(feature = "serde")]
 impl Serialize for NearGas {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@ pub struct NearGas {
 }
 mod utils;
 use std::u64;
+
+use std::str::FromStr;
 pub use utils::*;
 
 const ONE_TERA_GAS: u64 = 10u64.pow(12);
@@ -60,6 +62,13 @@ impl std::str::FromStr for NearGas {
         };
         let gas = NearGas::from_gas(number);
         Ok(gas)
+    }
+}
+
+impl std::convert::TryFrom<String> for NearGas {
+    type Error = NearGasError;
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        NearGas::from_str(&s)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -591,4 +591,33 @@ mod test {
             ))
         );
     }
+    #[test]
+    fn near_gas_from_str_currency_tgas() {
+        assert_eq!(
+            NearGas::from_str("10 tgas").unwrap(),
+            NearGas::from_gas(10000000000000) // 14 digits
+        );
+        assert_eq!(
+            NearGas::from_str("10.055TERAGAS").unwrap(),
+            NearGas::from_gas(10055000000000) // 14 digits
+        );
+    }
+    #[test]
+    fn near_gas_from_str_currency_gigagas() {
+        assert_eq!(
+            NearGas::from_str("10 gigagas").unwrap(),
+            NearGas::from_gas(10000000000) // 11 digits
+        );
+        assert_eq!(
+            NearGas::from_str("10GGAS ").unwrap(),
+            NearGas::from_gas(10000000000) // 11 digits
+        );
+    }
+    #[test]
+    fn near_gas_from_str_f64_tgas() {
+        assert_eq!(
+            NearGas::from_str("0.000001 tgas").unwrap(),
+            NearGas::from_gas(1000000) // 7 digits
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ impl std::fmt::Display for NearGas {
     }
 }
 
-impl std::fmt::Debug for NearGasError {
+impl std::fmt::Display for NearGasError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             NearGasError::IncorrectNumber(err) => write!(f, "Incorrect number: {:?}", err),
@@ -340,7 +340,7 @@ impl schemars::JsonSchema for NearGas {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NearGasError {
     IncorrectNumber(utils::DecimalNumberParsingError),
     IncorrectUnit(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,6 @@ impl std::fmt::Display for NearGas {
             } else if self.inner / ONE_GIGA_GAS > 990 {
                 return write!(f, "1 Tgas");
             } else {
-                dbg!(tgas);
                 return write!(f, "{}.{:0>3} Tgas", tgas, (self.inner / ONE_GIGA_GAS));
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,25 @@ impl std::str::FromStr for NearGas {
     }
 }
 
+impl std::fmt::Display for NearGas {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.as_gas() == 0 {
+            return write!(f, "0 Tgas");
+        }
+        let tgas = self.as_tgas();
+        if tgas > 0 {
+            write!(f, "{} Tgas", tgas)
+        } else {
+            let float = self.as_gas() as f64 / ONE_TERA_GAS as f64;
+            if float < 0.001 {
+                return write!(f, "<0.001 Tgas");
+            } else {
+                return write!(f, "{:.1$} Tgas", float, 3);
+            }
+        }
+    }
+}
+
 impl NearGas {
     /// Creates a new `NearGas` from the specified number of whole tera Gas.
     ///
@@ -485,5 +504,14 @@ mod test {
         let another_gas = 20;
         assert_eq!(gas.clone().saturating_div(rhs), NearGas::from_gas(5));
         assert_eq!(gas.saturating_div(another_gas), NearGas::from_gas(0));
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(NearGas::from_tgas(17).to_string(), "17 Tgas");
+        assert_eq!(NearGas::from_ggas(17).to_string(), "0.017 Tgas");
+        assert_eq!(NearGas::from_gas(17).to_string(), "<0.001 Tgas");
+        assert_eq!(NearGas::from_gas(0).to_string(), "0 Tgas");
+        assert_eq!(NearGas::from_gas(1_000_000_000_017).to_string(), "1 Tgas");
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@
 /// If the string slice has invalid chars, it will return the error `DecimalNumberParsingError::InvalidNumber`.
 ///
 /// If the whole part of the number has a value more than the `u64` maximum value, it will return the error `DecimalNumberParsingError::LongWhole`.
-///  
+///
 /// # Examples
 /// ```
 /// use near_gas::*;
@@ -16,7 +16,6 @@
 /// let prefix = 100000u64;
 /// assert_eq!(parse_decimal_number(number, prefix).unwrap(), 265790u64);
 /// ```
-use std::error::Error;
 pub fn parse_decimal_number(s: &str, pref_const: u64) -> Result<u64, DecimalNumberParsingError> {
     //mast be chenged also in near_balanse!!!
     let (int, fract) = if let Some((whole, fractional)) = s.trim().split_once('.') {
@@ -63,8 +62,8 @@ pub enum DecimalNumberParsingError {
     LongFractional(String),
 }
 
-impl Error for DecimalNumberParsingError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
+impl std::error::Error for DecimalNumberParsingError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         None
     }
 
@@ -72,7 +71,7 @@ impl Error for DecimalNumberParsingError {
         "description() is deprecated; use Display"
     }
 
-    fn cause(&self) -> Option<&dyn Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         self.source()
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,6 +16,7 @@
 /// let prefix = 100000u64;
 /// assert_eq!(parse_decimal_number(number, prefix).unwrap(), 265790u64);
 /// ```
+use std::error::Error;
 pub fn parse_decimal_number(s: &str, pref_const: u64) -> Result<u64, DecimalNumberParsingError> {
     //mast be chenged also in near_balanse!!!
     let (int, fract) = if let Some((whole, fractional)) = s.trim().split_once('.') {
@@ -60,6 +61,36 @@ pub enum DecimalNumberParsingError {
     InvalidNumber(String),
     LongWhole(String),
     LongFractional(String),
+}
+
+impl Error for DecimalNumberParsingError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+
+    fn description(&self) -> &str {
+        "description() is deprecated; use Display"
+    }
+
+    fn cause(&self) -> Option<&dyn Error> {
+        self.source()
+    }
+}
+
+impl std::fmt::Display for DecimalNumberParsingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DecimalNumberParsingError::InvalidNumber(s) => {
+                write!(f, "Invalid number: {}", s)
+            }
+            DecimalNumberParsingError::LongWhole(s) => {
+                write!(f, "Long whole part: {}", s)
+            }
+            DecimalNumberParsingError::LongFractional(s) => {
+                write!(f, "Long fractional part: {}", s)
+            }
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Resolves #2 and supersedes #3.

After a second thought, I decided that it is better to always ceil the result, so (1 Tgas + 1 gas) will be displayed as 1.1 Tgas as if someone sees that execution took 1.0 Tgas and decides to use it as a limit anywhere, the execution will fail.